### PR TITLE
fix typo in doc template

### DIFF
--- a/doc/class-Address.html
+++ b/doc/class-Address.html
@@ -1192,15 +1192,15 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-AddressCommon.html#methods">AddressCommon</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-AddressCommon.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_API_removeWhereIamUsed">API_removeWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_API_replaceWhereIamUsed">API_replaceWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#___replaceWhereIamUsed">__replaceWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_hasDescendants">hasDescendantso()</a>, 
-			<a href="class-AddressCommon.html#_isGroup">isGroupo()</a>, 
-			<a href="class-AddressCommon.html#_removeWhereIamUsed">removeWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_replaceWhereIamUsed">replaceWhereIamUsedo()</a>
+			<a href="class-AddressCommon.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_API_removeWhereIamUsed">API_removeWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_API_replaceWhereIamUsed">API_replaceWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#___replaceWhereIamUsed">__replaceWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_hasDescendants">hasDescendants()</a>, 
+			<a href="class-AddressCommon.html#_isGroup">isGroup()</a>, 
+			<a href="class-AddressCommon.html#_removeWhereIamUsed">removeWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_replaceWhereIamUsed">replaceWhereIamUsed()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1208,25 +1208,25 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">super_removeReferenceo()</a>(as super_removeReference())
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">super_removeReference()</a>(as super_removeReference())
 		</code></td>
 	</tr>
 	</table>
@@ -1234,9 +1234,9 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1244,11 +1244,11 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1256,11 +1256,11 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AddressCommon.html
+++ b/doc/class-AddressCommon.html
@@ -672,25 +672,25 @@ lower levels</p>
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">super_removeReferenceo()</a>(as super_removeReference())
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">super_removeReference()</a>(as super_removeReference())
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AddressGroup.html
+++ b/doc/class-AddressGroup.html
@@ -1526,9 +1526,9 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1536,11 +1536,11 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1548,17 +1548,17 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-AddressCommon.html#methods">AddressCommon</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-AddressCommon.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_API_removeWhereIamUsed">API_removeWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_API_replaceWhereIamUsed">API_replaceWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#___replaceWhereIamUsed">__replaceWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_hasDescendants">hasDescendantso()</a>, 
-			<a href="class-AddressCommon.html#_isAddress">isAddresso()</a>, 
-			<a href="class-AddressCommon.html#_isTmpAddr">isTmpAddro()</a>, 
-			<a href="class-AddressCommon.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-AddressCommon.html#_removeWhereIamUsed">removeWhereIamUsedo()</a>, 
-			<a href="class-AddressCommon.html#_replaceWhereIamUsed">replaceWhereIamUsedo()</a>
+			<a href="class-AddressCommon.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_API_removeWhereIamUsed">API_removeWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_API_replaceWhereIamUsed">API_replaceWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#___replaceWhereIamUsed">__replaceWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_hasDescendants">hasDescendants()</a>, 
+			<a href="class-AddressCommon.html#_isAddress">isAddress()</a>, 
+			<a href="class-AddressCommon.html#_isTmpAddr">isTmpAddr()</a>, 
+			<a href="class-AddressCommon.html#_removeReference">removeReference()</a>, 
+			<a href="class-AddressCommon.html#_removeWhereIamUsed">removeWhereIamUsed()</a>, 
+			<a href="class-AddressCommon.html#_replaceWhereIamUsed">replaceWhereIamUsed()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1566,25 +1566,25 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">super_removeReferenceo()</a>(as super_removeReference())
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">super_removeReference()</a>(as super_removeReference())
 		</code></td>
 	</tr>
 	</table>
@@ -1592,11 +1592,11 @@ $network is partially matched by this object.</p>
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AddressRuleContainer.html
+++ b/doc/class-AddressRuleContainer.html
@@ -1186,9 +1186,9 @@ resolution</dd>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1196,10 +1196,10 @@ resolution</dd>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AddressStore.html
+++ b/doc/class-AddressStore.html
@@ -1473,9 +1473,9 @@ don't exist in the conf.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AggregateEthernetIfStore.html
+++ b/doc/class-AggregateEthernetIfStore.html
@@ -288,9 +288,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -298,11 +298,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AggregateEthernetInterface.html
+++ b/doc/class-AggregateEthernetInterface.html
@@ -336,11 +336,11 @@
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTmpType">isTmpTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTunnelType">isTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isVlanType">isVlanTypeo()</a>
+			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackType()</a>, 
+			<a href="class-InterfaceType.html#_isTmpType">isTmpType()</a>, 
+			<a href="class-InterfaceType.html#_isTunnelType">isTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isVlanType">isVlanType()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -348,11 +348,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -360,9 +360,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -370,27 +370,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-App.html
+++ b/doc/class-App.html
@@ -510,27 +510,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -538,9 +538,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AppOverrideRule.html
+++ b/doc/class-AppOverrideRule.html
@@ -784,13 +784,13 @@
 	<caption>Methods used from <a href="class-NegatableRule.html#methods">NegatableRule</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXmlo()</a>, 
-			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegatedo()</a>
+			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXml()</a>, 
+			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegated()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -798,9 +798,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -808,7 +808,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -816,7 +816,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -824,11 +824,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -836,11 +836,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AppRuleContainer.html
+++ b/doc/class-AppRuleContainer.html
@@ -912,9 +912,9 @@ become 'any' and won't let you do so.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -922,11 +922,11 @@ become 'any' and won't let you do so.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AppStore.html
+++ b/doc/class-AppStore.html
@@ -580,9 +580,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -590,11 +590,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-AuthenticationRule.html
+++ b/doc/class-AuthenticationRule.html
@@ -647,13 +647,13 @@
 	<caption>Methods used from <a href="class-NegatableRule.html#methods">NegatableRule</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXmlo()</a>, 
-			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegatedo()</a>
+			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXml()</a>, 
+			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegated()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -661,9 +661,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -671,7 +671,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -679,7 +679,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -687,11 +687,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -699,11 +699,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-CaptivePortalRule.html
+++ b/doc/class-CaptivePortalRule.html
@@ -625,13 +625,13 @@
 	<caption>Methods used from <a href="class-NegatableRule.html#methods">NegatableRule</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXmlo()</a>, 
-			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegatedo()</a>
+			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXml()</a>, 
+			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegated()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -639,9 +639,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -649,7 +649,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -657,7 +657,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -665,11 +665,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -677,11 +677,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-DecryptionRule.html
+++ b/doc/class-DecryptionRule.html
@@ -531,13 +531,13 @@
 	<caption>Methods used from <a href="class-NegatableRule.html#methods">NegatableRule</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXmlo()</a>, 
-			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegatedo()</a>
+			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXml()</a>, 
+			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegated()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -545,9 +545,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -555,7 +555,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -563,7 +563,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -571,11 +571,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -583,11 +583,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-DeviceGroup.html
+++ b/doc/class-DeviceGroup.html
@@ -583,9 +583,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -593,10 +593,10 @@
 	<caption>Methods used from <a href="class-PanSubHelperTrait.html#methods">PanSubHelperTrait</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewallo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanoramao()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplateo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystemo()</a>
+			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewall()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanorama()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplate()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystem()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-DoSRule.html
+++ b/doc/class-DoSRule.html
@@ -748,13 +748,13 @@
 	<caption>Methods used from <a href="class-NegatableRule.html#methods">NegatableRule</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXmlo()</a>, 
-			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegatedo()</a>
+			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXml()</a>, 
+			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegated()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -762,9 +762,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -772,7 +772,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -780,7 +780,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -788,11 +788,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -800,11 +800,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-EthernetIfStore.html
+++ b/doc/class-EthernetIfStore.html
@@ -714,9 +714,9 @@ of the list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -724,11 +724,11 @@ of the list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-EthernetInterface.html
+++ b/doc/class-EthernetInterface.html
@@ -1116,12 +1116,12 @@ string</p>
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_isAggregateType">isAggregateTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTmpType">isTmpTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTunnelType">isTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isVlanType">isVlanTypeo()</a>
+			<a href="class-InterfaceType.html#_isAggregateType">isAggregateType()</a>, 
+			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackType()</a>, 
+			<a href="class-InterfaceType.html#_isTmpType">isTmpType()</a>, 
+			<a href="class-InterfaceType.html#_isTunnelType">isTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isVlanType">isVlanType()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1129,11 +1129,11 @@ string</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1141,9 +1141,9 @@ string</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1151,27 +1151,27 @@ string</p>
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-IKEGateway.html
+++ b/doc/class-IKEGateway.html
@@ -541,17 +541,17 @@
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_isAggregateType">isAggregateTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isEthernetType">isEthernetTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTmpType">isTmpTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTunnelType">isTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isVlanType">isVlanTypeo()</a>, 
-			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Addresso()</a>
+			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_isAggregateType">isAggregateType()</a>, 
+			<a href="class-InterfaceType.html#_isEthernetType">isEthernetType()</a>, 
+			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackType()</a>, 
+			<a href="class-InterfaceType.html#_isTmpType">isTmpType()</a>, 
+			<a href="class-InterfaceType.html#_isTunnelType">isTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isVlanType">isVlanType()</a>, 
+			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Address()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -559,11 +559,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -571,9 +571,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -581,27 +581,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-IKEGatewayStore.html
+++ b/doc/class-IKEGatewayStore.html
@@ -478,9 +478,9 @@ list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -488,11 +488,11 @@ list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-IPSecCryptoProfil.html
+++ b/doc/class-IPSecCryptoProfil.html
@@ -505,17 +505,17 @@ IPsecCryptoProfil name?)</p>
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_isAggregateType">isAggregateTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isEthernetType">isEthernetTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTmpType">isTmpTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTunnelType">isTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isVlanType">isVlanTypeo()</a>, 
-			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Addresso()</a>
+			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_isAggregateType">isAggregateType()</a>, 
+			<a href="class-InterfaceType.html#_isEthernetType">isEthernetType()</a>, 
+			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackType()</a>, 
+			<a href="class-InterfaceType.html#_isTmpType">isTmpType()</a>, 
+			<a href="class-InterfaceType.html#_isTunnelType">isTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isVlanType">isVlanType()</a>, 
+			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Address()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -523,11 +523,11 @@ IPsecCryptoProfil name?)</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -535,9 +535,9 @@ IPsecCryptoProfil name?)</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -545,27 +545,27 @@ IPsecCryptoProfil name?)</p>
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-IPSecCryptoProfileStore.html
+++ b/doc/class-IPSecCryptoProfileStore.html
@@ -476,9 +476,9 @@ of the list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -486,11 +486,11 @@ of the list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-IPsecTunnel.html
+++ b/doc/class-IPsecTunnel.html
@@ -744,16 +744,16 @@ name?)</p>
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_isAggregateType">isAggregateTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isEthernetType">isEthernetTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTmpType">isTmpTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTunnelType">isTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isVlanType">isVlanTypeo()</a>, 
-			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Addresso()</a>
+			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_isAggregateType">isAggregateType()</a>, 
+			<a href="class-InterfaceType.html#_isEthernetType">isEthernetType()</a>, 
+			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackType()</a>, 
+			<a href="class-InterfaceType.html#_isTmpType">isTmpType()</a>, 
+			<a href="class-InterfaceType.html#_isTunnelType">isTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isVlanType">isVlanType()</a>, 
+			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Address()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -761,11 +761,11 @@ name?)</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -773,9 +773,9 @@ name?)</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -783,27 +783,27 @@ name?)</p>
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-IPsecTunnelStore.html
+++ b/doc/class-IPsecTunnelStore.html
@@ -509,9 +509,9 @@ list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -519,11 +519,11 @@ list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-IkeCryptoProfil.html
+++ b/doc/class-IkeCryptoProfil.html
@@ -505,17 +505,17 @@ name?)</p>
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_isAggregateType">isAggregateTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isEthernetType">isEthernetTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTmpType">isTmpTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTunnelType">isTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isVlanType">isVlanTypeo()</a>, 
-			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Addresso()</a>
+			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_isAggregateType">isAggregateType()</a>, 
+			<a href="class-InterfaceType.html#_isEthernetType">isEthernetType()</a>, 
+			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackType()</a>, 
+			<a href="class-InterfaceType.html#_isTmpType">isTmpType()</a>, 
+			<a href="class-InterfaceType.html#_isTunnelType">isTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isVlanType">isVlanType()</a>, 
+			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Address()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -523,11 +523,11 @@ name?)</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -535,9 +535,9 @@ name?)</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -545,27 +545,27 @@ name?)</p>
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-IkeCryptoProfileStore.html
+++ b/doc/class-IkeCryptoProfileStore.html
@@ -476,9 +476,9 @@ the list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -486,11 +486,11 @@ the list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-InterfaceContainer.html
+++ b/doc/class-InterfaceContainer.html
@@ -525,9 +525,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -535,11 +535,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-LoopbackIfStore.html
+++ b/doc/class-LoopbackIfStore.html
@@ -566,9 +566,9 @@ of the list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -576,11 +576,11 @@ of the list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-LoopbackInterface.html
+++ b/doc/class-LoopbackInterface.html
@@ -461,16 +461,16 @@
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_isAggregateType">isAggregateTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isEthernetType">isEthernetTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTmpType">isTmpTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTunnelType">isTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isVlanType">isVlanTypeo()</a>, 
-			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Addresso()</a>
+			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_isAggregateType">isAggregateType()</a>, 
+			<a href="class-InterfaceType.html#_isEthernetType">isEthernetType()</a>, 
+			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isTmpType">isTmpType()</a>, 
+			<a href="class-InterfaceType.html#_isTunnelType">isTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isVlanType">isVlanType()</a>, 
+			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Address()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -478,11 +478,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -490,9 +490,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -500,27 +500,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ManagedDevice.html
+++ b/doc/class-ManagedDevice.html
@@ -438,27 +438,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -466,9 +466,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -476,11 +476,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ManagedDeviceStore.html
+++ b/doc/class-ManagedDeviceStore.html
@@ -365,9 +365,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -375,11 +375,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-NatRule.html
+++ b/doc/class-NatRule.html
@@ -1370,9 +1370,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1380,7 +1380,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1388,7 +1388,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1396,11 +1396,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1408,11 +1408,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-NetworkPropertiesContainer.html
+++ b/doc/class-NetworkPropertiesContainer.html
@@ -525,9 +525,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ObjRuleContainer.html
+++ b/doc/class-ObjRuleContainer.html
@@ -888,9 +888,9 @@ store.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -898,11 +898,11 @@ store.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ObjStore.html
+++ b/doc/class-ObjStore.html
@@ -670,9 +670,9 @@ it and return it.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -680,11 +680,11 @@ it and return it.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-PANConf.html
+++ b/doc/class-PANConf.html
@@ -811,9 +811,9 @@ $vsys1-&gt;display_statistics();</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -821,10 +821,10 @@ $vsys1-&gt;display_statistics();</p>
 	<caption>Methods used from <a href="class-PanSubHelperTrait.html#methods">PanSubHelperTrait</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroupo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanoramao()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplateo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystemo()</a>
+			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroup()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanorama()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplate()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystem()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-PanoramaConf.html
+++ b/doc/class-PanoramaConf.html
@@ -926,9 +926,9 @@ $fromRunning = TRUE</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -936,10 +936,10 @@ $fromRunning = TRUE</p>
 	<caption>Methods used from <a href="class-PanSubHelperTrait.html#methods">PanSubHelperTrait</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroupo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewallo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplateo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystemo()</a>
+			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroup()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewall()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplate()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystem()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-PbfRule.html
+++ b/doc/class-PbfRule.html
@@ -636,13 +636,13 @@
 	<caption>Methods used from <a href="class-NegatableRule.html#methods">NegatableRule</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXmlo()</a>, 
-			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegatedo()</a>
+			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXml()</a>, 
+			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegated()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -650,9 +650,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -660,7 +660,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -668,7 +668,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -676,11 +676,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -688,11 +688,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-QoSRule.html
+++ b/doc/class-QoSRule.html
@@ -560,13 +560,13 @@
 	<caption>Methods used from <a href="class-NegatableRule.html#methods">NegatableRule</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXmlo()</a>, 
-			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegatedo()</a>
+			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXml()</a>, 
+			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegated()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -574,9 +574,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -584,7 +584,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -592,7 +592,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -600,11 +600,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -612,11 +612,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-Rule.html
+++ b/doc/class-Rule.html
@@ -1636,9 +1636,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1646,7 +1646,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1654,7 +1654,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1662,11 +1662,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1674,11 +1674,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-RuleStore.html
+++ b/doc/class-RuleStore.html
@@ -2308,9 +2308,9 @@ time. You should not need to call it by yourself in normal situations</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -2318,11 +2318,11 @@ time. You should not need to call it by yourself in normal situations</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-RuleWithUserID.html
+++ b/doc/class-RuleWithUserID.html
@@ -544,9 +544,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -554,7 +554,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -562,7 +562,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -570,11 +570,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -582,11 +582,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-SecurityRule.html
+++ b/doc/class-SecurityRule.html
@@ -2413,13 +2413,13 @@
 	<caption>Methods used from <a href="class-NegatableRule.html#methods">NegatableRule</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXmlo()</a>, 
-			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegatedo()</a>, 
-			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegatedo()</a>
+			<a href="class-NegatableRule.html#_API_setDestinationIsNegated">API_setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_API_setSourceIsNegated">API_setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#__readNegationFromXml">_readNegationFromXml()</a>, 
+			<a href="class-NegatableRule.html#_destinationIsNegated">destinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setDestinationIsNegated">setDestinationIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_setSourceIsNegated">setSourceIsNegated()</a>, 
+			<a href="class-NegatableRule.html#_sourceIsNegated">sourceIsNegated()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -2427,9 +2427,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -2437,7 +2437,7 @@
 	<caption>Methods used from <a href="class-centralServiceStoreUser.html#methods">centralServiceStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStoreo()</a>
+			<a href="class-centralServiceStoreUser.html#_findParentServiceStore">findParentServiceStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -2445,7 +2445,7 @@
 	<caption>Methods used from <a href="class-centralAddressStoreUser.html#methods">centralAddressStoreUser</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStoreo()</a>
+			<a href="class-centralAddressStoreUser.html#_findParentAddressStore">findParentAddressStore()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -2453,11 +2453,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -2465,11 +2465,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-Service.html
+++ b/doc/class-Service.html
@@ -967,9 +967,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -977,11 +977,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -989,11 +989,11 @@
 	<caption>Methods used from <a href="class-ObjectWithDescription.html#methods">ObjectWithDescription</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxmlo()</a>, 
-			<a href="class-ObjectWithDescription.html#_description">descriptiono()</a>, 
-			<a href="class-ObjectWithDescription.html#_description_merge">description_mergeo()</a>, 
-			<a href="class-ObjectWithDescription.html#_setDescription">setDescriptiono()</a>
+			<a href="class-ObjectWithDescription.html#_API_setDescription">API_setDescription()</a>, 
+			<a href="class-ObjectWithDescription.html#__load_description_from_domxml">_load_description_from_domxml()</a>, 
+			<a href="class-ObjectWithDescription.html#_description">description()</a>, 
+			<a href="class-ObjectWithDescription.html#_description_merge">description_merge()</a>, 
+			<a href="class-ObjectWithDescription.html#_setDescription">setDescription()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1001,14 +1001,14 @@
 	<caption>Methods used from <a href="class-ServiceCommon.html#methods">ServiceCommon</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ServiceCommon.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_API_removeWhereIamUsed">API_removeWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_API_replaceWhereIamUsed">API_replaceWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#___replaceWhereIamUsed">__replaceWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_isGroup">isGroupo()</a>, 
-			<a href="class-ServiceCommon.html#_removeWhereIamUsed">removeWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_replaceWhereIamUsed">replaceWhereIamUsedo()</a>
+			<a href="class-ServiceCommon.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_API_removeWhereIamUsed">API_removeWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_API_replaceWhereIamUsed">API_replaceWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#___replaceWhereIamUsed">__replaceWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_isGroup">isGroup()</a>, 
+			<a href="class-ServiceCommon.html#_removeWhereIamUsed">removeWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_replaceWhereIamUsed">replaceWhereIamUsed()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1016,25 +1016,25 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">super_removeReferenceo()</a>(as super_removeReference())
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">super_removeReference()</a>(as super_removeReference())
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ServiceCommon.html
+++ b/doc/class-ServiceCommon.html
@@ -624,25 +624,25 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">super_removeReferenceo()</a>(as super_removeReference())
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">super_removeReference()</a>(as super_removeReference())
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ServiceGroup.html
+++ b/doc/class-ServiceGroup.html
@@ -1138,9 +1138,9 @@ their members inserted<br />
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1148,11 +1148,11 @@ their members inserted<br />
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1160,16 +1160,16 @@ their members inserted<br />
 	<caption>Methods used from <a href="class-ServiceCommon.html#methods">ServiceCommon</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ServiceCommon.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_API_removeWhereIamUsed">API_removeWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_API_replaceWhereIamUsed">API_replaceWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#___replaceWhereIamUsed">__replaceWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_isService">isServiceo()</a>, 
-			<a href="class-ServiceCommon.html#_isTmpSrv">isTmpSrvo()</a>, 
-			<a href="class-ServiceCommon.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ServiceCommon.html#_removeWhereIamUsed">removeWhereIamUsedo()</a>, 
-			<a href="class-ServiceCommon.html#_replaceWhereIamUsed">replaceWhereIamUsedo()</a>
+			<a href="class-ServiceCommon.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_API_removeWhereIamUsed">API_removeWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_API_replaceWhereIamUsed">API_replaceWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#___replaceWhereIamUsed">__replaceWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_isService">isService()</a>, 
+			<a href="class-ServiceCommon.html#_isTmpSrv">isTmpSrv()</a>, 
+			<a href="class-ServiceCommon.html#_removeReference">removeReference()</a>, 
+			<a href="class-ServiceCommon.html#_removeWhereIamUsed">removeWhereIamUsed()</a>, 
+			<a href="class-ServiceCommon.html#_replaceWhereIamUsed">replaceWhereIamUsed()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1177,25 +1177,25 @@ their members inserted<br />
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">super_removeReferenceo()</a>(as super_removeReference())
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">super_removeReference()</a>(as super_removeReference())
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ServiceRuleContainer.html
+++ b/doc/class-ServiceRuleContainer.html
@@ -1210,9 +1210,9 @@ looking to compare similar rules.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1220,11 +1220,11 @@ looking to compare similar rules.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ServiceStore.html
+++ b/doc/class-ServiceStore.html
@@ -1445,9 +1445,9 @@ with that name already exists</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -1455,11 +1455,11 @@ with that name already exists</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-StaticRoute.html
+++ b/doc/class-StaticRoute.html
@@ -528,11 +528,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -540,9 +540,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -550,27 +550,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-Tag.html
+++ b/doc/class-Tag.html
@@ -858,27 +858,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -886,9 +886,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -896,11 +896,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-TagRuleContainer.html
+++ b/doc/class-TagRuleContainer.html
@@ -704,9 +704,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -714,11 +714,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-TagStore.html
+++ b/doc/class-TagStore.html
@@ -746,9 +746,9 @@ it and return it.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -756,11 +756,11 @@ it and return it.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-Template.html
+++ b/doc/class-Template.html
@@ -391,26 +391,26 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -418,9 +418,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -428,10 +428,10 @@
 	<caption>Methods used from <a href="class-PanSubHelperTrait.html#methods">PanSubHelperTrait</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroupo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewallo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanoramao()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystemo()</a>
+			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroup()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewall()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanorama()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystem()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-TemplateStack.html
+++ b/doc/class-TemplateStack.html
@@ -362,26 +362,26 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -389,9 +389,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -399,11 +399,11 @@
 	<caption>Methods used from <a href="class-PanSubHelperTrait.html#methods">PanSubHelperTrait</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroupo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewallo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanoramao()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplateo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystemo()</a>
+			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroup()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewall()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanorama()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplate()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isVirtualSystem">isVirtualSystem()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-TmpInterface.html
+++ b/doc/class-TmpInterface.html
@@ -300,27 +300,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -328,9 +328,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -338,16 +338,16 @@
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_isAggregateType">isAggregateTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isEthernetType">isEthernetTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTunnelType">isTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isVlanType">isVlanTypeo()</a>, 
-			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Addresso()</a>
+			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_isAggregateType">isAggregateType()</a>, 
+			<a href="class-InterfaceType.html#_isEthernetType">isEthernetType()</a>, 
+			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackType()</a>, 
+			<a href="class-InterfaceType.html#_isTunnelType">isTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isVlanType">isVlanType()</a>, 
+			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Address()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-TmpInterfaceStore.html
+++ b/doc/class-TmpInterfaceStore.html
@@ -329,9 +329,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -339,11 +339,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-TunnelIfStore.html
+++ b/doc/class-TunnelIfStore.html
@@ -566,9 +566,9 @@ the list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -576,11 +576,11 @@ the list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-TunnelInterface.html
+++ b/doc/class-TunnelInterface.html
@@ -461,16 +461,16 @@
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_isAggregateType">isAggregateTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isEthernetType">isEthernetTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTmpType">isTmpTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isVlanType">isVlanTypeo()</a>, 
-			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Addresso()</a>
+			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_isAggregateType">isAggregateType()</a>, 
+			<a href="class-InterfaceType.html#_isEthernetType">isEthernetType()</a>, 
+			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackType()</a>, 
+			<a href="class-InterfaceType.html#_isTmpType">isTmpType()</a>, 
+			<a href="class-InterfaceType.html#_isVlanType">isVlanType()</a>, 
+			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Address()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -478,11 +478,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -490,9 +490,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -500,27 +500,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-VirtualRouter.html
+++ b/doc/class-VirtualRouter.html
@@ -517,11 +517,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -529,9 +529,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -539,27 +539,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-VirtualRouterStore.html
+++ b/doc/class-VirtualRouterStore.html
@@ -505,9 +505,9 @@ the list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -515,11 +515,11 @@ the list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-VirtualSystem.html
+++ b/doc/class-VirtualSystem.html
@@ -506,9 +506,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -516,10 +516,10 @@
 	<caption>Methods used from <a href="class-PanSubHelperTrait.html#methods">PanSubHelperTrait</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroupo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewallo()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanoramao()</a>, 
-			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplateo()</a>
+			<a href="class-PanSubHelperTrait.html#_isDeviceGroup">isDeviceGroup()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isFirewall">isFirewall()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isPanorama">isPanorama()</a>, 
+			<a href="class-PanSubHelperTrait.html#_isTemplate">isTemplate()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-VirtualWire.html
+++ b/doc/class-VirtualWire.html
@@ -501,11 +501,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -513,9 +513,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -523,27 +523,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-VirtualWireStore.html
+++ b/doc/class-VirtualWireStore.html
@@ -572,9 +572,9 @@ list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -582,11 +582,11 @@ list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-VlanIfStore.html
+++ b/doc/class-VlanIfStore.html
@@ -566,9 +566,9 @@ the list.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -576,11 +576,11 @@ the list.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-VlanInterface.html
+++ b/doc/class-VlanInterface.html
@@ -428,16 +428,16 @@
 	<caption>Methods used from <a href="class-InterfaceType.html#methods">InterfaceType</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Addresso()</a>, 
-			<a href="class-InterfaceType.html#_isAggregateType">isAggregateTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isEthernetType">isEthernetTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTmpType">isTmpTypeo()</a>, 
-			<a href="class-InterfaceType.html#_isTunnelType">isTunnelTypeo()</a>, 
-			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Addresso()</a>
+			<a href="class-InterfaceType.html#_API_addIPv4Address">API_addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_API_removeIPv4Address">API_removeIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_addIPv4Address">addIPv4Address()</a>, 
+			<a href="class-InterfaceType.html#_isAggregateType">isAggregateType()</a>, 
+			<a href="class-InterfaceType.html#_isEthernetType">isEthernetType()</a>, 
+			<a href="class-InterfaceType.html#_isIPsecTunnelType">isIPsecTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_isLoopbackType">isLoopbackType()</a>, 
+			<a href="class-InterfaceType.html#_isTmpType">isTmpType()</a>, 
+			<a href="class-InterfaceType.html#_isTunnelType">isTunnelType()</a>, 
+			<a href="class-InterfaceType.html#_removeIPv4Address">removeIPv4Address()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -445,11 +445,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -457,9 +457,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -467,27 +467,27 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addObjectWhereIamUsed">addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-Zone.html
+++ b/doc/class-Zone.html
@@ -498,26 +498,26 @@
 	<caption>Methods used from <a href="class-ReferencableObject.html#methods">ReferencableObject</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsedo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidationo()</a>, 
-			<a href="class-ReferencableObject.html#_addReference">addReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChangeo()</a>, 
-			<a href="class-ReferencableObject.html#_countReferences">countReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_display_references">display_referenceso()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRuleso()</a>, 
-			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClasso()</a>, 
-			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashCompo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferences">getReferenceso()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocationo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStoreo()</a>, 
-			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesTypeo()</a>, 
-			<a href="class-ReferencableObject.html#_name">nameo()</a>, 
-			<a href="class-ReferencableObject.html#_removeReference">removeReferenceo()</a>, 
-			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGloballyo()</a>, 
-			<a href="class-ReferencableObject.html#_setRefName">setRefNameo()</a>
+			<a href="class-ReferencableObject.html#_API_addObjectWhereIamUsed">API_addObjectWhereIamUsed()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesStoreValidation">ReferencesStoreValidation()</a>, 
+			<a href="class-ReferencableObject.html#_ReferencesTypeValidation">ReferencesTypeValidation()</a>, 
+			<a href="class-ReferencableObject.html#_addReference">addReference()</a>, 
+			<a href="class-ReferencableObject.html#_broadcastMyNameChange">broadcastMyNameChange()</a>, 
+			<a href="class-ReferencableObject.html#_countReferences">countReferences()</a>, 
+			<a href="class-ReferencableObject.html#_display_references">display_references()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedRule_byType">findAssociatedRule_byType()</a>, 
+			<a href="class-ReferencableObject.html#_findAssociatedSecurityRules">findAssociatedSecurityRules()</a>, 
+			<a href="class-ReferencableObject.html#_findReferencesWithClass">findReferencesWithClass()</a>, 
+			<a href="class-ReferencableObject.html#_generateRefHashComp">generateRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getRefHashComp">getRefHashComp()</a>, 
+			<a href="class-ReferencableObject.html#_getReferences">getReferences()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesLocation">getReferencesLocation()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesStore">getReferencesStore()</a>, 
+			<a href="class-ReferencableObject.html#_getReferencesType">getReferencesType()</a>, 
+			<a href="class-ReferencableObject.html#_name">name()</a>, 
+			<a href="class-ReferencableObject.html#_removeReference">removeReference()</a>, 
+			<a href="class-ReferencableObject.html#_replaceMeGlobally">replaceMeGlobally()</a>, 
+			<a href="class-ReferencableObject.html#_setRefName">setRefName()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -525,9 +525,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -535,11 +535,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ZoneRuleContainer.html
+++ b/doc/class-ZoneRuleContainer.html
@@ -846,9 +846,9 @@ useful when looking to compare similar rules.</p>
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -856,11 +856,11 @@ useful when looking to compare similar rules.</p>
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>

--- a/doc/class-ZoneStore.html
+++ b/doc/class-ZoneStore.html
@@ -670,9 +670,9 @@
 	<caption>Methods used from <a href="class-PathableName.html#methods">PathableName</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortNameo()</a>, 
-			<a href="class-PathableName.html#_getLocationString">getLocationStringo()</a>, 
-			<a href="class-PathableName.html#_toString">toStringo()</a>
+			<a href="class-PathableName.html#__PANC_shortName">_PANC_shortName()</a>, 
+			<a href="class-PathableName.html#_getLocationString">getLocationString()</a>, 
+			<a href="class-PathableName.html#_toString">toString()</a>
 		</code></td>
 	</tr>
 	</table>
@@ -680,11 +680,11 @@
 	<caption>Methods used from <a href="class-XmlConvertible.html#methods">XmlConvertible</a></caption>
 	<tr>
 		<td><code>
-			<a href="class-XmlConvertible.html#_API_sync">API_synco()</a>, 
-			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText">getXmlTexto()</a>, 
-			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inlineo()</a>, 
-			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attributeo()</a>
+			<a href="class-XmlConvertible.html#_API_sync">API_sync()</a>, 
+			<a href="class-XmlConvertible.html#_getChildXmlText_inline">getChildXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText">getXmlText()</a>, 
+			<a href="class-XmlConvertible.html#_getXmlText_inline">getXmlText_inline()</a>, 
+			<a href="class-XmlConvertible.html#_set_node_attribute">set_node_attribute()</a>
 		</code></td>
 	</tr>
 	</table>


### PR DESCRIPTION
Fixed a typo in doc template related to used method names on class pages.